### PR TITLE
feat: 공통 모듈에 Member 관련 클래스 생성

### DIFF
--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -20,11 +20,13 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
 }
 
 tasks.named('test') {

--- a/module-common/src/main/java/com/gaethering/modulecommon/domain/BaseTimeEntity.java
+++ b/module-common/src/main/java/com/gaethering/modulecommon/domain/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.gaethering.modulecommon.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/module-common/src/main/java/com/gaethering/modulecommon/domain/Member.java
+++ b/module-common/src/main/java/com/gaethering/modulecommon/domain/Member.java
@@ -1,0 +1,43 @@
+package com.gaethering.modulecommon.domain;
+
+import com.gaethering.modulecommon.type.MemberStatus;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(unique = true)
+    private String email;
+
+    private String nickname;
+
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    private LocalDateTime accessDate;
+
+    private boolean isEmailAuth;
+
+}

--- a/module-common/src/main/java/com/gaethering/modulecommon/repository/MemberRepository.java
+++ b/module-common/src/main/java/com/gaethering/modulecommon/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.gaethering.modulecommon.repository;
+
+import com.gaethering.modulecommon.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/module-common/src/main/java/com/gaethering/modulecommon/type/MemberStatus.java
+++ b/module-common/src/main/java/com/gaethering/modulecommon/type/MemberStatus.java
@@ -1,0 +1,5 @@
+package com.gaethering.modulecommon.type;
+
+public enum MemberStatus {
+    ACTIVE, DORMANT, INACTIVE
+}

--- a/module-user/build.gradle
+++ b/module-user/build.gradle
@@ -8,14 +8,21 @@ group = 'com.gaethering'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
 repositories {
 	mavenCentral()
 }
 
 dependencies {
-
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'com.h2database:h2'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	implementation project(':module-common')

--- a/module-user/src/main/java/com/gaethering/moduleuser/ModuleUserApplication.java
+++ b/module-user/src/main/java/com/gaethering/moduleuser/ModuleUserApplication.java
@@ -2,10 +2,16 @@ package com.gaethering.moduleuser;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(
     scanBasePackages = {"com.gaethering.modulecommon", "com.gaethering.moduleuser"}
 )
+@EntityScan("com.gaethering.modulecommon.domain")
+@EnableJpaRepositories(basePackages = "com.gaethering.modulecommon.repository")
+@EnableJpaAuditing
 public class ModuleUserApplication {
 
     public static void main(String[] args) {

--- a/module-user/src/test/java/com/gaethering/moduleuser/repository/MemberRepositoryTest.java
+++ b/module-user/src/test/java/com/gaethering/moduleuser/repository/MemberRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.gaethering.moduleuser.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.gaethering.modulecommon.domain.Member;
+import com.gaethering.modulecommon.repository.MemberRepository;
+import com.gaethering.modulecommon.type.MemberStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void saveMember_Success() {
+        //given
+        Member member = Member.builder()
+            .email("gaethering@gmail.com")
+            .nickname("개더링")
+            .password("1234qwer!")
+            .status(MemberStatus.ACTIVE)
+            .accessDate(LocalDateTime.now())
+            .isEmailAuth(true)
+            .build();
+
+        //when
+        Member savedMember = memberRepository.save(member);
+
+        //then
+        assertEquals(savedMember.getStatus(), MemberStatus.ACTIVE);
+        assertNotNull(savedMember.getCreatedAt());
+        assertNotNull(savedMember.getUpdatedAt());
+     }
+
+}


### PR DESCRIPTION
- jpa 라이브러리가 module-user에 안들어오는 문제로 build.gradle 수정
- Member entity 작성
- MemberRepository 작성
- module-user에서 module-common의 엔티티와 레포지토리를 사용할 수 있도록 basepackage 지정